### PR TITLE
revert node-sass to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "helmet": "^4.6.0",
     "joi": "^17.4.0",
     "jsonwebtoken": "^8.5.1",
-    "node-sass": "^6.0.0",
+    "node-sass": "^5.0.0",
     "pbkdf2": "^3.1.2",
     "pg": "^8.6.0",
     "pg-hstore": "^2.3.3",


### PR DESCRIPTION
heroku build failed after this update so reverting back to prev. version